### PR TITLE
Parse text for the `jsoninclude-quote` directive as markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Parse the text for the `jsoninclude-quote` directive as markdown
+
 ## [0.4.0] - 2022-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2022-09-26
+
 ### Changed
 
 - Parse the text for the `jsoninclude-quote` directive as markdown

--- a/docs/_static/example_schema.json
+++ b/docs/_static/example_schema.json
@@ -19,7 +19,7 @@
         },
         "lorem": {
             "title": "Lorem ipsum",
-            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur porttitor urna in diam ornare luctus. Donec accumsan sit amet velit id auctor. Sed commodo elit ut tempor suscipit. Fusce volutpat malesuada felis, accumsan molestie nisi aliquet non. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.",
+            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur porttitor urna in diam ornare luctus. Donec accumsan sit amet velit id auctor. Sed commodo elit ut tempor suscipit. Fusce volutpat malesuada felis, accumsan molestie nisi aliquet non. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. *Some* [markdown](http://example.org).",
             "type": "string"
         },
         "subthings": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sphinxcontrib-opendataservices',
-    version='0.4.0',
+    version='0.5.0',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
     packages=['sphinxcontrib'],

--- a/sphinxcontrib/opendataservices.py
+++ b/sphinxcontrib/opendataservices.py
@@ -132,7 +132,7 @@ class JSONIncludeQuote(JSONInclude):
     def run(self):
         filename, pointed = self.get_filename_and_pointed()
         block_quote = nodes.block_quote('')
-        block_quote += nodes.paragraph(pointed, pointed)
+        block_quote += parse_markdown(pointed, document=self.state.document)
         return [block_quote]
 
 

--- a/tests/fixtures/jsoninclude-quote.html
+++ b/tests/fixtures/jsoninclude-quote.html
@@ -2,7 +2,13 @@
     <div class="bodywrapper">
         <div class="body" role="main">
             <blockquote>
-                <div><p>Some text</p></div>
+                <div><p>
+                    Some text 
+                    <em>some</em> 
+                    <a class="reference external" href="http://example.org">
+                        markdown
+                    </a>
+                </p></div>
             </blockquote>
         </div>
     </div>

--- a/tests/fixtures/jsoninclude-quote/example.json
+++ b/tests/fixtures/jsoninclude-quote/example.json
@@ -1,5 +1,5 @@
 {
     "a": [{
-        "b": "Some text"
+        "b": "Some text *some* [markdown](http://example.org)"
     }]
 }


### PR DESCRIPTION
Example: https://sphinxcontrib-opendataservices.readthedocs.io/en/jsoninclude-quote-markdown/jsoninclude/#json-include-quoted