### PR TITLE
requirements: Delete pre_requirements.txt

### DIFF
--- a/pre_requirements.txt
+++ b/pre_requirements.txt
@@ -1,3 +1,0 @@
-# pip master, and latest setuptools to fix https://github.com/pypa/pip/issues/4216
--e git+https://github.com/pypa/pip.git@5a8b11cbe4b5e143e3ef6ebacfabe831b620f93b#egg=pip
-setuptools==37.0.0


### PR DESCRIPTION
This was a bodge to get readthedocs to work correctly, and shouldn't be required any more.

Closes #44